### PR TITLE
Updated action runner_type to python-script

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+# 0.4.0
+
+- Updated action `runner_type` from `run-python` to `python-script`
+
 # 0.2.0
 
 - Rename `config.yaml` to `config.schema.yaml` and update to use schema.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ It should contain:
 You can also use dynamic values from the datastore. See the
 [docs](https://docs.stackstorm.com/reference/pack_configs.html) for more info.
 
+**Note** : When modifying the configuration in `/opt/stackstorm/configs/` please
+           remember to tell StackStorm to load these new values by running
+           `st2ctl reload --register-configs`
+
 ## Actions
 
 * `delete` - Delete value from Vault server

--- a/actions/create_token.yaml
+++ b/actions/create_token.yaml
@@ -1,7 +1,7 @@
 ---
 name: create_token
 pack: vault
-runner_type: run-python
+runner_type: python-script
 description: "Create a new Token"
 enabled: true
 entry_point: "create_token.py"

--- a/actions/delete.yaml
+++ b/actions/delete.yaml
@@ -1,6 +1,6 @@
 ---
 name: delete
-runner_type: run-python
+runner_type: python-script
 description: "Delete value from Vault server"
 enabled: true
 entry_point: "delete.py"

--- a/actions/delete_policy.yaml
+++ b/actions/delete_policy.yaml
@@ -1,7 +1,7 @@
 ---
 name: delete_policy
 pack: vault
-runner_type: run-python
+runner_type: python-script
 description: "Delete policy from Vault server"
 enabled: true
 entry_point: "delete_policy.py"

--- a/actions/get_policy.yaml
+++ b/actions/get_policy.yaml
@@ -1,7 +1,7 @@
 ---
 name: get_policy
 pack: vault
-runner_type: run-python
+runner_type: python-script
 description: "Read policy from Vault server"
 enabled: true
 entry_point: "get_policy.py"

--- a/actions/is_initialized.yaml
+++ b/actions/is_initialized.yaml
@@ -1,6 +1,6 @@
 ---
 name: is_initialized
-runner_type: run-python
+runner_type: python-script
 description: "Read initialization status from Vault server"
 enabled: true
 entry_point: "is_initialized.py"

--- a/actions/list_policies.yaml
+++ b/actions/list_policies.yaml
@@ -1,6 +1,6 @@
 ---
 name: list_policies
-runner_type: run-python
+runner_type: python-script
 description: "List Policies from Vault server"
 enabled: true
 entry_point: "list_policies.py"

--- a/actions/read.yaml
+++ b/actions/read.yaml
@@ -1,6 +1,6 @@
 ---
 name: read
-runner_type: run-python
+runner_type: python-script
 description: "Read value from Vault server"
 enabled: true
 entry_point: "read.py"

--- a/actions/set_policy.yaml
+++ b/actions/set_policy.yaml
@@ -1,7 +1,7 @@
 ---
 name: set_policy
 pack: vault
-runner_type: run-python
+runner_type: python-script
 description: "Create a new Vault policy"
 enabled: true
 entry_point: "set_policy.py"

--- a/actions/write.yaml
+++ b/actions/write.yaml
@@ -1,6 +1,6 @@
 ---
 name: write
-runner_type: run-python
+runner_type: python-script
 description: "Write a key/value to Vault"
 enabled: true
 entry_point: "write.py"

--- a/pack.yaml
+++ b/pack.yaml
@@ -2,7 +2,7 @@
 ref: vault
 name: vault
 description: vault
-version: 0.3.0
+version: 0.4.0
 author: steve.neuharth
 email: steve.neuharth@target.com
 contributors:


### PR DESCRIPTION
Updated action `runner_type` from `run-python` to `python-script` based on the following issue: https://github.com/StackStorm/st2/issues/3389 .

Also, updated README.md with a note on running `st2ctl reload --register-configs` when performing config modifications.