### PR TITLE
Alter VaultBaseAction to pass cert correctly to hvac

### DIFF
--- a/actions/lib/action.py
+++ b/actions/lib/action.py
@@ -11,8 +11,15 @@ class VaultBaseAction(Action):
     def _get_client(self):
         url = self.config['url']
         token = self.config['token']
-        cert = self.config['cert']
-        verify = self.config['verify']
+        verify = self._get_verify()
 
-        client = hvac.Client(url=url, token=token, cert=cert, verify=verify)
+        client = hvac.Client(url=url, token=token, verify=verify)
         return client
+
+    def _get_verify(self):
+        verify = self.config['verify']
+        cert = self.config['cert']
+        if verify:
+            if cert and cert != '':
+                return cert
+        return verify


### PR DESCRIPTION
hvac expects verify to overload with the cert path, NOT be passed as `cert`

My team implemented this change on our own internal fork, and is currently running successfully in a few ST2 installations.

See https://gist.github.com/StephenWeber/e931b51788826964fc604a52ef66a85f for a test suite that exercises the logic inside.

Fixes #11