### PR TITLE
Alter VaultBaseAction to pass cert correctly to hvac

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.5.2
+
+- Pass certificate correctly to hvac
+
 ## 0.5.1
 
 - Version bump to fix tagging issues

--- a/actions/lib/action.py
+++ b/actions/lib/action.py
@@ -19,7 +19,6 @@ class VaultBaseAction(Action):
     def _get_verify(self):
         verify = self.config['verify']
         cert = self.config['cert']
-        if verify:
-            if cert and cert != '':
-                return cert
+        if verify and cert:
+            return cert
         return verify

--- a/actions/lib/action.py
+++ b/actions/lib/action.py
@@ -11,8 +11,15 @@ class VaultBaseAction(Action):
     def _get_client(self):
         url = self.config['url']
         token = self.config['token']
-        cert = self.config['cert']
-        verify = self.config['verify']
+        verify = self._get_verify()
 
-        client = hvac.Client(url=url, token=token, cert=cert, verify=verify)
+        client = hvac.Client(url=url, token=token, verify=verify)
         return client
+
+    def _get_verify(self):
+        verify = self.config['verify']
+        cert = self.config['cert']
+        if verify:
+            if cert and cert != '':
+                return cert
+        return verify

--- a/pack.yaml
+++ b/pack.yaml
@@ -2,7 +2,7 @@
 ref: vault
 name: vault
 description: HashiCorp Vault
-version: 0.5.1
+version: 0.5.2
 python_versions:
   - "2"
   - "3"


### PR DESCRIPTION
hvac expects verify to overload with the cert path, NOT be passed as cert

My team implemented this change on our own internal fork, and is currently running successfully in a few ST2 installations.

See https://gist.github.com/StephenWeber/e931b51788826964fc604a52ef66a85f for a test suite that exercises the logic inside.

Fixes #11

Replaces #12