### PR TITLE
Drop deprecated API usage in HVAC

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,16 @@
 # Change Log
 
+## 0.6.0
+
+WARNING: This is the last version that "supports" python2.7.
+The next version will be 1.0.0 and "2" will be dropped from python_versions.
+
+- Add ability to authenticate with approle instead of with token.
+- Drop testing with python2.7 due to broken infrastructure.
+- Add unit tests for all actions.
+- Update minimum required version of hvac to 0.10.6.
+- Migrate from deprecated hvac methods to their replacements.
+
 ## 0.5.2
 
 - Pass certificate correctly to hvac

--- a/actions/delete_policy.py
+++ b/actions/delete_policy.py
@@ -3,4 +3,4 @@ from lib import action
 
 class VaultPolicyDeleteAction(action.VaultBaseAction):
     def run(self, name):
-        return self.vault.delete_policy(name)
+        return self.vault.sys.delete_policy(name)

--- a/actions/is_initialized.py
+++ b/actions/is_initialized.py
@@ -3,4 +3,4 @@ from lib import action
 
 class VaultIsInitializedAction(action.VaultBaseAction):
     def run(self):
-        return self.vault.is_initialized()
+        return self.vault.sys.is_initialized()

--- a/actions/read_kv.py
+++ b/actions/read_kv.py
@@ -6,10 +6,13 @@ class VaultReadKVAction(action.VaultBaseAction):
         value = None
 
         if kv_version == 1:
-            value = self.vault.kv.v1.read_secret(path=path, mount_point=mount_point)
+            value = self.vault.secrets.kv.v1.read_secret(
+                path=path, mount_point=mount_point
+            )
         elif kv_version == 2:
-            value = self.vault.kv.v2.read_secret_version(path=path, mount_point=mount_point,
-                                                         version=version)
+            value = self.vault.secrets.kv.v2.read_secret_version(
+                path=path, mount_point=mount_point, version=version
+            )
 
         if value:
             return value['data']

--- a/actions/set_policy.py
+++ b/actions/set_policy.py
@@ -3,4 +3,4 @@ from lib import action
 
 class VaultPolicySetAction(action.VaultBaseAction):
     def run(self, name, rules):
-        return self.vault.set_policy(name, rules)
+        return self.vault.sys.create_or_update_policy(name, rules)

--- a/pack.yaml
+++ b/pack.yaml
@@ -2,7 +2,7 @@
 ref: vault
 name: vault
 description: HashiCorp Vault
-version: 0.5.2
+version: 0.6.0
 python_versions:
   - "2"
   - "3"

--- a/tests/test_action_delete_policy.py
+++ b/tests/test_action_delete_policy.py
@@ -1,3 +1,5 @@
+from requests import Response
+
 from delete_policy import VaultPolicyDeleteAction
 from tests.vault_action_tests_base import VaultActionTestCase
 
@@ -12,7 +14,7 @@ class PolicyDeleteActionTestCase(VaultActionTestCase):
         # test
         action = self.get_action_instance(config=self.dummy_pack_config)
         action_result = action.run(name="stanley")
-        self.assertIsNone(action_result)
+        self.assertIsInstance(action_result, Response)
 
         result = self.client.get_policy("stanley")
         self.assertIsNone(result)

--- a/tests/test_action_set_policy.py
+++ b/tests/test_action_set_policy.py
@@ -1,3 +1,5 @@
+from requests import Response
+
 from set_policy import VaultPolicySetAction
 from tests.vault_action_tests_base import VaultActionTestCase
 
@@ -18,7 +20,7 @@ class PolicySetActionTestCase(VaultActionTestCase):
             name="stanley",
             rules=rules_text,
         )
-        self.assertIsNone(action_result)
+        self.assertIsInstance(action_result, Response)
 
         result = self.client.get_policy("stanley")
         self.assertEqual(result, rules_text)


### PR DESCRIPTION
#14 adjusts requirements to use `hvac>=0.10.6`, which is the latest.
hvac has had significant refactoring, moving the python API to new
locations. We do not need to keep anything that is deprecated.