### PR TITLE
Use get_policy helper instead of diy

### DIFF
--- a/actions/get_policy.py
+++ b/actions/get_policy.py
@@ -3,4 +3,4 @@ from lib import action
 
 class VaultGetPolicyAction(action.VaultBaseAction):
     def run(self, name):
-        return self.vault.read("/sys/policy/" + name)['rules']
+        return self.vault.get_policy(name)


### PR DESCRIPTION
The `vault.get_policy` method has more error catching logic, but it
essentially does the same thing that we are doing in the `get_policy`
action. So, adopt the safer version, and use the upstream version.