### PR TITLE
Action tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,8 @@ jobs:
       # Don't install various StackStorm dependencies which are already
       # installed by CI again in the various check scripts
       ST2_INSTALL_DEPS: "0"
+      # 3.3 is the last version to support python27
+      ST2_BRANCH: "v3.3"
 
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,9 +26,13 @@ jobs:
           # can't intercept the error and cause non-fatal exit in case pack
           # doesn't declare support for Python 3
           shell: /bin/bash
+          # TODO: delete last 3 lines when StackStorm-Exchange/ci#101 is merged
           command: |
             git clone -b master git://github.com/stackstorm-exchange/ci.git ~/ci
             ~/ci/.circle/dependencies ; ~/ci/.circle/exit_on_py3_checks $?
+            echo "Setting up custom pack testing environment with tests/setup_testing_env.sh"
+            source ~/virtualenv/bin/activate
+            tests/setup_testing_env.sh
       - run:
           name: Run tests (Python 3.6)
           # NOTE: We don't want to use default "-e" option because this means

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,50 +1,6 @@
 version: 2
 
 jobs:
-  build_and_test_python27:
-    docker:
-      - image: circleci/python:2.7
-      - image: rabbitmq:3
-      - image: mongo:3.4
-
-    working_directory: ~/repo
-
-    environment:
-      VIRTUALENV_DIR: "~/virtualenv"
-      # Don't install various StackStorm dependencies which are already
-      # installed by CI again in the various check scripts
-      ST2_INSTALL_DEPS: "0"
-      # 3.3 is the last version to support python27
-      ST2_BRANCH: "v3.3"
-
-    steps:
-      - checkout
-      - restore_cache:
-          key: v1-dependency-cache-py27-{{ checksum "requirements.txt" }}
-      - run:
-          name: Download dependencies
-          command: |
-            git clone -b master git://github.com/stackstorm-exchange/ci.git ~/ci
-            ~/ci/.circle/dependencies
-      - run:
-          name: Run tests (Python 2.7)
-          command: ~/ci/.circle/test
-      - save_cache:
-          key: v1-dependency-cache-py27-{{ checksum "requirements.txt" }}
-          paths:
-            - ~/.cache/pip
-            - ~/.apt-cache
-      # NOTE: We use virtualenv files from Python 2.7 step in "deploy" job so we
-      # only persist paths from this job
-      - persist_to_workspace:
-          root: /
-          paths:
-            - home/circleci/ci
-            - home/circleci/virtualenv
-            - tmp/st2
-            - home/circleci/repo
-            - home/circleci/.gitconfig
-
   # NOTE: Until we add "python_version" metadata attribute to pack.yaml and
   # explicitly call which packs work with Python 3.x, Python 3.x failures are
   # not considered fatal
@@ -119,18 +75,15 @@ workflows:
   # Workflow which runs on each push
   build_test_deploy_on_push:
     jobs:
-      - build_and_test_python27
       - build_and_test_python36
       - deploy:
           requires:
-            - build_and_test_python27
             - build_and_test_python36
           filters:
             branches:
               only: master
   build_test_weekly:
     jobs:
-      - build_and_test_python27
       - build_and_test_python36
     # Workflow which runs nightly - note we don't perform deploy job on nightly
     # build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,6 @@
 version: 2
 
 jobs:
-  # NOTE: Until we add "python_version" metadata attribute to pack.yaml and
-  # explicitly call which packs work with Python 3.x, Python 3.x failures are
-  # not considered fatal
   build_and_test_python36:
     docker:
       - image: circleci/python:3.6
@@ -45,10 +42,21 @@ jobs:
           paths:
             - ~/.cache/pip
             - ~/.apt-cache
+      # NOTE: We use virtualenv files from Python 3.6 step in "deploy" job so we
+      # only persist paths from this job
+      - persist_to_workspace:
+          root: /
+          paths:
+            - home/circleci/ci
+            - home/circleci/virtualenv
+            - tmp/st2
+            - home/circleci/repo
+            - home/circleci/.gitconfig
+
 
   deploy:
     docker:
-      - image: circleci/python:2.7
+      - image: circleci/python:3.6
 
     working_directory: ~/repo
 
@@ -58,7 +66,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: v1-dependency-cache-py27-{{ checksum "requirements.txt" }}
+          key: v1-dependency-cache-py36-{{ checksum "requirements.txt" }}
       - attach_workspace:
           at: /
       - run:
@@ -67,8 +75,11 @@ jobs:
             sudo apt-get update
             sudo apt -y install gmic optipng
       - run:
+          # NOTE: We try to retry the script up to 5 times if it fails. The command could fail due
+          # to the race (e.g. we try to push changes to index, but index has been updated by some
+          # other pack in the mean time)
           name: Update exchange.stackstorm.org
-          command:  ~/ci/.circle/deployment
+          command: ~/ci/.circle/retry_on_failure.sh ~/ci/.circle/deployment
 
 workflows:
   version: 2

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
+# hvac tests (see tests/setup_testing_env.sh)
+# - hvac is where CI checks out the git repo
+hvac
+# - tests/utils should be a symlink to tests/utils in an hvac git checkout
+tests/utils
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 hvac
 # - tests/utils should be a symlink to tests/utils in an hvac git checkout
 tests/utils
+tests/config_files
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/actions/list_policies.py
+++ b/actions/list_policies.py
@@ -1,6 +1,6 @@
 from lib import action
 
 
-class VaultReadAction(action.VaultBaseAction):
+class VaultPolicyListAction(action.VaultBaseAction):
     def run(self):
         return self.vault.list_policies()

--- a/actions/read_kv.py
+++ b/actions/read_kv.py
@@ -1,7 +1,7 @@
 from lib import action
 
 
-class VaultReadAction(action.VaultBaseAction):
+class VaultReadKVAction(action.VaultBaseAction):
     def run(self, path, kv_version, mount_point, version):
         value = None
 

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,0 +1,2 @@
+# do we need parser (pyhcl) for the actions as well or just tests?
+hvac[parser]

--- a/tests/fixtures/config.py
+++ b/tests/fixtures/config.py
@@ -1,0 +1,9 @@
+dummy_config = {
+    "url": "https://example.com",
+    "token": "1234567890",
+    "auth_mode": "token",
+    "cert": "",
+    "verify": True,
+    "role_id": None,
+    "secret_id": None,
+}

--- a/tests/fixtures/config.py
+++ b/tests/fixtures/config.py
@@ -1,9 +1,0 @@
-dummy_config = {
-    "url": "https://example.com",
-    "token": "1234567890",
-    "auth_mode": "token",
-    "cert": "",
-    "verify": True,
-    "role_id": None,
-    "secret_id": None,
-}

--- a/tests/setup_testing_env.sh
+++ b/tests/setup_testing_env.sh
@@ -31,5 +31,6 @@ HOME=${HVAC_DIR} ${HVAC_DIR}/tests/scripts/install-vault.sh
 # tests.utils also uses config_files, so make that available
 for x in utils config_files; do
     rm -f ${ROOT_DIR}/tests/${x}
-    ln -s ${HVAC_DIR}/tests/${x} ${ROOT_DIR}/tests/${x}
+    # relative (-r) allows the symlink to work in vagrant
+    ln -rs ${HVAC_DIR}/tests/${x} ${ROOT_DIR}/tests/${x}
 done

--- a/tests/setup_testing_env.sh
+++ b/tests/setup_testing_env.sh
@@ -20,13 +20,9 @@ HVAC_DIR="${ROOT_DIR}/hvac"
 # main = the release branch; devel = the active development branch
 git clone -b main git://github.com/hvac/hvac.git "${HVAC_DIR}"
 
-# This script needs to work both in CI, and for local testing.
-#
-# These scripts "install" the binaries in ${HOME}/bin by default,
-# which is only ok in CI. To avoid passing in Consul/Vault VERSION (as $1),
-# we specify install dir with $HOME instead of CONSUL_DIR (as $2).
-HOME=${VIRTUAL_ENV:-${HVAC_DIR}} ${HVAC_DIR}/tests/scripts/install-consul.sh
-HOME=${VIRTUAL_ENV:-${HVAC_DIR}} ${HVAC_DIR}/tests/scripts/install-vault.sh
+# These scripts "install" the binaries in ${HOME}/.local/bin by default.
+${HVAC_DIR}/tests/scripts/install-consul.sh
+${HVAC_DIR}/tests/scripts/install-vault.sh
 
 # using symlinks allows us to import tests.utils.* without adding the rest of the hvac tests.
 # tests.utils also uses config_files, so make that available

--- a/tests/setup_testing_env.sh
+++ b/tests/setup_testing_env.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -eux
 
 # For python deps, please use requirements.txt or requirements-test.txt.
 # Do not install python requirements with this script.

--- a/tests/setup_testing_env.sh
+++ b/tests/setup_testing_env.sh
@@ -24,8 +24,8 @@ git clone -b master git://github.com/hvac/hvac.git "${HVAC_DIR}"
 # These scripts "install" the binaries in ${HOME}/bin by default,
 # which is only ok in CI. To avoid passing in Consul/Vault VERSION (as $1),
 # we specify install dir with $HOME instead of CONSUL_DIR (as $2).
-HOME=${HVAC_DIR} ${HVAC_DIR}/tests/scripts/install-consul.sh
-HOME=${HVAC_DIR} ${HVAC_DIR}/tests/scripts/install-vault.sh
+HOME=${VIRTUAL_ENV:-${HVAC_DIR}} ${HVAC_DIR}/tests/scripts/install-consul.sh
+HOME=${VIRTUAL_ENV:-${HVAC_DIR}} ${HVAC_DIR}/tests/scripts/install-vault.sh
 
 # using symlinks allows us to import tests.utils.* without adding the rest of the hvac tests.
 # tests.utils also uses config_files, so make that available

--- a/tests/setup_testing_env.sh
+++ b/tests/setup_testing_env.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# For python deps, please use requirements.txt or requirements-test.txt.
+# Do not install python requirements with this script.
+
+# Some packs need to install and configure additional packages to properly
+# run their test suite. Other packs need to clone other repositories to
+# reuse standardized testing infrastructure. And other functional or end-to-end
+# tests might need additional system setup to access external APIs via
+# an enterprise bus or something else.
+# That is the purpose of this script. Setup the testing environment
+# to do mock-less regression or end-to-end testing.
+
+# This script is called by `deployment` housed in StackStorm-exchange/ci.
+# `deployment` will only run this script if it is executable.
+ROOT_DIR="${ROOT_DIR:-$(pwd)}"
+HVAC_DIR="${ROOT_DIR}/hvac"
+HVAC_VAULT_VERSION="${HVAC_VAULT_VERSION:-STABLE}"
+HVAC_VAULT_LICENSE="${HVAC_VAULT_LICENSE:-OSS}"
+
+# master = the release branch; devel = the active development branch
+git clone -b master git://github.com/hvac/hvac.git "${HVAC_DIR}"
+
+# This script needs to work both in CI, and for local testing.
+# These scripts "install" the binaries in ${HOME}/bin by default, which is
+# only ok in CI. To avoid passing in CONSUL_VERSION (as $1), we specify install
+# dir with $HOME instead of CONSUL_DIR (as $2).
+HOME=${HVAC_DIR} ${HVAC_DIR}/tests/scripts/install-consul.sh
+${HVAC_DIR}/tests/scripts/install-vault.sh ${HVAC_VAULT_VERSION} ${HVAC_VAULT_LICENSE} ${HVAC_DIR}/bin
+
+# hvac uses tox+nosetests to run tests
+# using a symlink allows us to import tests.utils.* without adding the rest of the hvac tests.
+rm -f ${ROOT_DIR}/tests/utils
+ln -s ${HVAC_DIR}/tests/utils ${ROOT_DIR}/tests/utils

--- a/tests/setup_testing_env.sh
+++ b/tests/setup_testing_env.sh
@@ -16,8 +16,8 @@
 ROOT_DIR="${ROOT_DIR:-$(pwd)}"
 HVAC_DIR="${ROOT_DIR}/hvac"
 
-# master = the release branch; devel = the active development branch
-git clone -b master git://github.com/hvac/hvac.git "${HVAC_DIR}"
+# main = the release branch; devel = the active development branch
+git clone -b main git://github.com/hvac/hvac.git "${HVAC_DIR}"
 
 # This script needs to work both in CI, and for local testing.
 #

--- a/tests/setup_testing_env.sh
+++ b/tests/setup_testing_env.sh
@@ -15,20 +15,21 @@
 # `deployment` will only run this script if it is executable.
 ROOT_DIR="${ROOT_DIR:-$(pwd)}"
 HVAC_DIR="${ROOT_DIR}/hvac"
-HVAC_VAULT_VERSION="${HVAC_VAULT_VERSION:-STABLE}"
-HVAC_VAULT_LICENSE="${HVAC_VAULT_LICENSE:-OSS}"
 
 # master = the release branch; devel = the active development branch
 git clone -b master git://github.com/hvac/hvac.git "${HVAC_DIR}"
 
 # This script needs to work both in CI, and for local testing.
-# These scripts "install" the binaries in ${HOME}/bin by default, which is
-# only ok in CI. To avoid passing in CONSUL_VERSION (as $1), we specify install
-# dir with $HOME instead of CONSUL_DIR (as $2).
+#
+# These scripts "install" the binaries in ${HOME}/bin by default,
+# which is only ok in CI. To avoid passing in Consul/Vault VERSION (as $1),
+# we specify install dir with $HOME instead of CONSUL_DIR (as $2).
 HOME=${HVAC_DIR} ${HVAC_DIR}/tests/scripts/install-consul.sh
-${HVAC_DIR}/tests/scripts/install-vault.sh ${HVAC_VAULT_VERSION} ${HVAC_VAULT_LICENSE} ${HVAC_DIR}/bin
+HOME=${HVAC_DIR} ${HVAC_DIR}/tests/scripts/install-vault.sh
 
-# hvac uses tox+nosetests to run tests
-# using a symlink allows us to import tests.utils.* without adding the rest of the hvac tests.
-rm -f ${ROOT_DIR}/tests/utils
-ln -s ${HVAC_DIR}/tests/utils ${ROOT_DIR}/tests/utils
+# using symlinks allows us to import tests.utils.* without adding the rest of the hvac tests.
+# tests.utils also uses config_files, so make that available
+for x in utils config_files; do
+    rm -f ${ROOT_DIR}/tests/${x}
+    ln -s ${HVAC_DIR}/tests/${x} ${ROOT_DIR}/tests/${x}
+done

--- a/tests/test_action_create_token.py
+++ b/tests/test_action_create_token.py
@@ -1,10 +1,11 @@
 from st2tests.base import BaseActionTestCase
 
 from create_token import VaultCreateTokenAction
+from .fixtures.config import dummy_config
 
 class CreateTokenActionTestCase(BaseActionTestCase):
     action_cls = VaultCreateTokenAction
 
     def test_method(self):
-        action = self.get_action_instance(config={'foo': 'bar'})
+        action = self.get_action_instance(config=dummy_config)
         result = action.run()

--- a/tests/test_action_create_token.py
+++ b/tests/test_action_create_token.py
@@ -3,9 +3,21 @@ from st2tests.base import BaseActionTestCase
 from create_token import VaultCreateTokenAction
 from .fixtures.config import dummy_config
 
+
 class CreateTokenActionTestCase(BaseActionTestCase):
     action_cls = VaultCreateTokenAction
 
     def test_method(self):
         action = self.get_action_instance(config=dummy_config)
-        result = action.run()
+        result = action.run(
+            # token_id=None,
+            # policies=None,
+            # meta=None,
+            # no_parent=False,
+            # display_name=None,
+            # num_uses=None,
+            # no_default_policy=False,
+            # ttl=None,
+            # orphan=False,
+            # wrap_ttl=None,
+        )

--- a/tests/test_action_create_token.py
+++ b/tests/test_action_create_token.py
@@ -23,4 +23,4 @@ class CreateTokenActionTestCase(VaultActionTestCase):
             # orphan=False,
             # wrap_ttl=None,
         )
-        assert result["auth"]["client_token"]
+        self.assertIsNotNone(result["auth"]["client_token"])

--- a/tests/test_action_create_token.py
+++ b/tests/test_action_create_token.py
@@ -1,14 +1,12 @@
-from st2tests.base import BaseActionTestCase
-
 from create_token import VaultCreateTokenAction
-from tests.fixtures.config import dummy_config
+from tests.vault_action_tests_base import VaultActionTestCase
 
 
-class CreateTokenActionTestCase(BaseActionTestCase):
+class CreateTokenActionTestCase(VaultActionTestCase):
     action_cls = VaultCreateTokenAction
 
     def test_method(self):
-        action = self.get_action_instance(config=dummy_config)
+        action = self.get_action_instance(config=self.dummy_pack_config)
         result = action.run(
             # token_id=None,
             # policies=None,

--- a/tests/test_action_create_token.py
+++ b/tests/test_action_create_token.py
@@ -1,0 +1,10 @@
+from st2tests.base import BaseActionTestCase
+
+from create_token import VaultCreateTokenAction
+
+class CreateTokenActionTestCase(BaseActionTestCase):
+    action_cls = VaultCreateTokenAction
+
+    def test_method(self):
+        action = self.get_action_instance(config={'foo': 'bar'})
+        result = action.run()

--- a/tests/test_action_create_token.py
+++ b/tests/test_action_create_token.py
@@ -1,7 +1,7 @@
 from st2tests.base import BaseActionTestCase
 
 from create_token import VaultCreateTokenAction
-from .fixtures.config import dummy_config
+from tests.fixtures.config import dummy_config
 
 
 class CreateTokenActionTestCase(BaseActionTestCase):

--- a/tests/test_action_create_token.py
+++ b/tests/test_action_create_token.py
@@ -5,6 +5,10 @@ from tests.vault_action_tests_base import VaultActionTestCase
 class CreateTokenActionTestCase(VaultActionTestCase):
     action_cls = VaultCreateTokenAction
 
+    # Use None here to avoid this error:
+    #   "expiring root tokens cannot create non-expiring root tokens"
+    default_token_lease = None
+
     def test_method(self):
         action = self.get_action_instance(config=self.dummy_pack_config)
         result = action.run(
@@ -19,3 +23,4 @@ class CreateTokenActionTestCase(VaultActionTestCase):
             # orphan=False,
             # wrap_ttl=None,
         )
+        assert result["auth"]["client_token"]

--- a/tests/test_action_delete.py
+++ b/tests/test_action_delete.py
@@ -5,6 +5,14 @@ from tests.vault_action_tests_base import VaultActionTestCase
 class DeleteActionTestCase(VaultActionTestCase):
     action_cls = VaultDeleteAction
 
-    def test_method(self):
+    def test_delete_existing_key(self):
+        # setup
+        self.client.write("secret/stanley", st2="awesome")
+
+        # test
         action = self.get_action_instance(config=self.dummy_pack_config)
-        result = action.run(path="")
+        action_result = action.run(path="secret/stanley")
+        # action_result is a requests.response object
+
+        result = self.client.read("secret/stanley")
+        assert result is None

--- a/tests/test_action_delete.py
+++ b/tests/test_action_delete.py
@@ -1,7 +1,7 @@
 from st2tests.base import BaseActionTestCase
 
 from delete import VaultDeleteAction
-from .fixtures.config import dummy_config
+from tests.fixtures.config import dummy_config
 
 
 class DeleteActionTestCase(BaseActionTestCase):

--- a/tests/test_action_delete.py
+++ b/tests/test_action_delete.py
@@ -1,10 +1,11 @@
 from st2tests.base import BaseActionTestCase
 
 from delete import VaultDeleteAction
+from .fixtures.config import dummy_config
 
 class DeleteActionTestCase(BaseActionTestCase):
     action_cls = VaultDeleteAction
 
     def test_method(self):
-        action = self.get_action_instance(config={'foo': 'bar'})
+        action = self.get_action_instance(config=dummy_config)
         result = action.run()

--- a/tests/test_action_delete.py
+++ b/tests/test_action_delete.py
@@ -1,0 +1,10 @@
+from st2tests.base import BaseActionTestCase
+
+from delete import VaultDeleteAction
+
+class DeleteActionTestCase(BaseActionTestCase):
+    action_cls = VaultDeleteAction
+
+    def test_method(self):
+        action = self.get_action_instance(config={'foo': 'bar'})
+        result = action.run()

--- a/tests/test_action_delete.py
+++ b/tests/test_action_delete.py
@@ -12,8 +12,8 @@ class DeleteActionTestCase(VaultActionTestCase):
         # test
         action = self.get_action_instance(config=self.dummy_pack_config)
         action_result = action.run(path="secret/stanley")
-        # action_result is a requests.response object
-        assert action_result is not None
+        # hvac does not return anything here
+        assert action_result is None
 
         result = self.client.read("secret/stanley")
         assert result is None

--- a/tests/test_action_delete.py
+++ b/tests/test_action_delete.py
@@ -13,7 +13,7 @@ class DeleteActionTestCase(VaultActionTestCase):
         action = self.get_action_instance(config=self.dummy_pack_config)
         action_result = action.run(path="secret/stanley")
         # hvac does not return anything here
-        assert action_result is None
+        self.assertIsNone(action_result)
 
         result = self.client.read("secret/stanley")
-        assert result is None
+        self.assertIsNone(result)

--- a/tests/test_action_delete.py
+++ b/tests/test_action_delete.py
@@ -3,9 +3,10 @@ from st2tests.base import BaseActionTestCase
 from delete import VaultDeleteAction
 from .fixtures.config import dummy_config
 
+
 class DeleteActionTestCase(BaseActionTestCase):
     action_cls = VaultDeleteAction
 
     def test_method(self):
         action = self.get_action_instance(config=dummy_config)
-        result = action.run()
+        result = action.run(path="")

--- a/tests/test_action_delete.py
+++ b/tests/test_action_delete.py
@@ -13,6 +13,7 @@ class DeleteActionTestCase(VaultActionTestCase):
         action = self.get_action_instance(config=self.dummy_pack_config)
         action_result = action.run(path="secret/stanley")
         # action_result is a requests.response object
+        assert action_result is not None
 
         result = self.client.read("secret/stanley")
         assert result is None

--- a/tests/test_action_delete.py
+++ b/tests/test_action_delete.py
@@ -1,12 +1,10 @@
-from st2tests.base import BaseActionTestCase
-
 from delete import VaultDeleteAction
-from tests.fixtures.config import dummy_config
+from tests.vault_action_tests_base import VaultActionTestCase
 
 
-class DeleteActionTestCase(BaseActionTestCase):
+class DeleteActionTestCase(VaultActionTestCase):
     action_cls = VaultDeleteAction
 
     def test_method(self):
-        action = self.get_action_instance(config=dummy_config)
+        action = self.get_action_instance(config=self.dummy_pack_config)
         result = action.run(path="")

--- a/tests/test_action_delete_policy.py
+++ b/tests/test_action_delete_policy.py
@@ -1,0 +1,10 @@
+from st2tests.base import BaseActionTestCase
+
+from delete_policy import VaultDeletePolicyAction
+
+class DeletePolicyActionTestCase(BaseActionTestCase):
+    action_cls = VaultDeletePolicyAction
+
+    def test_method(self):
+        action = self.get_action_instance(config={'foo': 'bar'})
+        result = action.run()

--- a/tests/test_action_delete_policy.py
+++ b/tests/test_action_delete_policy.py
@@ -6,5 +6,13 @@ class PolicyDeleteActionTestCase(VaultActionTestCase):
     action_cls = VaultPolicyDeleteAction
 
     def test_method(self):
+        # setup
+        self.prep_policy("stanley")
+
+        # test
         action = self.get_action_instance(config=self.dummy_pack_config)
-        result = action.run(name="")
+        action_result = action.run(name="stanley")
+        assert action_result is None
+
+        result = self.client.get_policy("stanley")
+        assert result is None

--- a/tests/test_action_delete_policy.py
+++ b/tests/test_action_delete_policy.py
@@ -1,12 +1,10 @@
-from st2tests.base import BaseActionTestCase
-
 from delete_policy import VaultPolicyDeleteAction
-from tests.fixtures.config import dummy_config
+from tests.vault_action_tests_base import VaultActionTestCase
 
 
-class PolicyDeleteActionTestCase(BaseActionTestCase):
+class PolicyDeleteActionTestCase(VaultActionTestCase):
     action_cls = VaultPolicyDeleteAction
 
     def test_method(self):
-        action = self.get_action_instance(config=dummy_config)
+        action = self.get_action_instance(config=self.dummy_pack_config)
         result = action.run(name="")

--- a/tests/test_action_delete_policy.py
+++ b/tests/test_action_delete_policy.py
@@ -1,7 +1,7 @@
 from st2tests.base import BaseActionTestCase
 
 from delete_policy import VaultPolicyDeleteAction
-from .fixtures.config import dummy_config
+from tests.fixtures.config import dummy_config
 
 
 class PolicyDeleteActionTestCase(BaseActionTestCase):

--- a/tests/test_action_delete_policy.py
+++ b/tests/test_action_delete_policy.py
@@ -12,7 +12,7 @@ class PolicyDeleteActionTestCase(VaultActionTestCase):
         # test
         action = self.get_action_instance(config=self.dummy_pack_config)
         action_result = action.run(name="stanley")
-        assert action_result is None
+        self.assertIsNone(action_result)
 
         result = self.client.get_policy("stanley")
-        assert result is None
+        self.assertIsNone(result)

--- a/tests/test_action_delete_policy.py
+++ b/tests/test_action_delete_policy.py
@@ -1,9 +1,9 @@
 from st2tests.base import BaseActionTestCase
 
-from delete_policy import VaultDeletePolicyAction
+from delete_policy import VaultPolicyDeleteAction
 
-class DeletePolicyActionTestCase(BaseActionTestCase):
-    action_cls = VaultDeletePolicyAction
+class PolicyDeleteActionTestCase(BaseActionTestCase):
+    action_cls = VaultPolicyDeleteAction
 
     def test_method(self):
         action = self.get_action_instance(config={'foo': 'bar'})

--- a/tests/test_action_delete_policy.py
+++ b/tests/test_action_delete_policy.py
@@ -3,9 +3,10 @@ from st2tests.base import BaseActionTestCase
 from delete_policy import VaultPolicyDeleteAction
 from .fixtures.config import dummy_config
 
+
 class PolicyDeleteActionTestCase(BaseActionTestCase):
     action_cls = VaultPolicyDeleteAction
 
     def test_method(self):
         action = self.get_action_instance(config=dummy_config)
-        result = action.run()
+        result = action.run(name="")

--- a/tests/test_action_delete_policy.py
+++ b/tests/test_action_delete_policy.py
@@ -1,10 +1,11 @@
 from st2tests.base import BaseActionTestCase
 
 from delete_policy import VaultPolicyDeleteAction
+from .fixtures.config import dummy_config
 
 class PolicyDeleteActionTestCase(BaseActionTestCase):
     action_cls = VaultPolicyDeleteAction
 
     def test_method(self):
-        action = self.get_action_instance(config={'foo': 'bar'})
+        action = self.get_action_instance(config=dummy_config)
         result = action.run()

--- a/tests/test_action_get_policy.py
+++ b/tests/test_action_get_policy.py
@@ -3,9 +3,10 @@ from st2tests.base import BaseActionTestCase
 from get_policy import VaultGetPolicyAction
 from .fixtures.config import dummy_config
 
+
 class GetPolicyActionTestCase(BaseActionTestCase):
     action_cls = VaultGetPolicyAction
 
     def test_method(self):
         action = self.get_action_instance(config=dummy_config)
-        result = action.run()
+        result = action.run(name="")

--- a/tests/test_action_get_policy.py
+++ b/tests/test_action_get_policy.py
@@ -1,7 +1,7 @@
 from st2tests.base import BaseActionTestCase
 
 from get_policy import VaultGetPolicyAction
-from .fixtures.config import dummy_config
+from tests.fixtures.config import dummy_config
 
 
 class GetPolicyActionTestCase(BaseActionTestCase):

--- a/tests/test_action_get_policy.py
+++ b/tests/test_action_get_policy.py
@@ -1,10 +1,11 @@
 from st2tests.base import BaseActionTestCase
 
 from get_policy import VaultGetPolicyAction
+from .fixtures.config import dummy_config
 
 class GetPolicyActionTestCase(BaseActionTestCase):
     action_cls = VaultGetPolicyAction
 
     def test_method(self):
-        action = self.get_action_instance(config={'foo': 'bar'})
+        action = self.get_action_instance(config=dummy_config)
         result = action.run()

--- a/tests/test_action_get_policy.py
+++ b/tests/test_action_get_policy.py
@@ -1,12 +1,10 @@
-from st2tests.base import BaseActionTestCase
-
 from get_policy import VaultGetPolicyAction
-from tests.fixtures.config import dummy_config
+from tests.vault_action_tests_base import VaultActionTestCase
 
 
-class GetPolicyActionTestCase(BaseActionTestCase):
+class GetPolicyActionTestCase(VaultActionTestCase):
     action_cls = VaultGetPolicyAction
 
     def test_method(self):
-        action = self.get_action_instance(config=dummy_config)
+        action = self.get_action_instance(config=self.dummy_pack_config)
         result = action.run(name="")

--- a/tests/test_action_get_policy.py
+++ b/tests/test_action_get_policy.py
@@ -6,5 +6,13 @@ class GetPolicyActionTestCase(VaultActionTestCase):
     action_cls = VaultGetPolicyAction
 
     def test_method(self):
+        # setup
+        rules_text, rules_obj = self.prep_policy("stanley")
+
+        # test
         action = self.get_action_instance(config=self.dummy_pack_config)
-        result = action.run(name="")
+        action_result = action.run(name="stanley")
+        assert action_result == rules_text
+
+        # cleanup
+        self.client.delete_policy("stanley")

--- a/tests/test_action_get_policy.py
+++ b/tests/test_action_get_policy.py
@@ -1,0 +1,10 @@
+from st2tests.base import BaseActionTestCase
+
+from get_policy import VaultGetPolicyAction
+
+class GetPolicyActionTestCase(BaseActionTestCase):
+    action_cls = VaultGetPolicyAction
+
+    def test_method(self):
+        action = self.get_action_instance(config={'foo': 'bar'})
+        result = action.run()

--- a/tests/test_action_get_policy.py
+++ b/tests/test_action_get_policy.py
@@ -12,7 +12,7 @@ class GetPolicyActionTestCase(VaultActionTestCase):
         # test
         action = self.get_action_instance(config=self.dummy_pack_config)
         action_result = action.run(name="stanley")
-        assert action_result == rules_text
+        self.assertEqual(action_result, rules_text)
 
         # cleanup
         self.client.delete_policy("stanley")

--- a/tests/test_action_get_policy.py
+++ b/tests/test_action_get_policy.py
@@ -7,7 +7,7 @@ class GetPolicyActionTestCase(VaultActionTestCase):
 
     def test_method(self):
         # setup
-        rules_text, rules_obj = self.prep_policy("stanley")
+        rules_text, _ = self.prep_policy("stanley")
 
         # test
         action = self.get_action_instance(config=self.dummy_pack_config)

--- a/tests/test_action_is_initialized.py
+++ b/tests/test_action_is_initialized.py
@@ -1,10 +1,11 @@
 from st2tests.base import BaseActionTestCase
 
 from is_initialized import VaultIsInitializedAction
+from .fixtures.config import dummy_config
 
 class IsInitializedActionTestCase(BaseActionTestCase):
     action_cls = VaultIsInitializedAction
 
     def test_method(self):
-        action = self.get_action_instance(config={'foo': 'bar'})
+        action = self.get_action_instance(config=dummy_config)
         result = action.run()

--- a/tests/test_action_is_initialized.py
+++ b/tests/test_action_is_initialized.py
@@ -8,17 +8,17 @@ class IsInitializedActionTestCase(VaultActionTestCase):
     def test_already_initialized(self):
         action = self.get_action_instance(config=self.dummy_pack_config)
         result = action.run()
-        assert result is True
+        self.assertTrue(result)
 
     def test_before_and_after_initialization(self):
         self.manager.restart_vault_cluster(perform_init=False)
 
         action = self.get_action_instance(config=self.dummy_pack_config)
         result = action.run()
-        assert result is False
+        self.assertFalse(result)
 
         self.manager.restart_vault_cluster(perform_init=True)
 
         action = self.get_action_instance(config=self.dummy_pack_config)
         result = action.run()
-        assert result is True
+        self.assertTrue(result)

--- a/tests/test_action_is_initialized.py
+++ b/tests/test_action_is_initialized.py
@@ -3,6 +3,7 @@ from st2tests.base import BaseActionTestCase
 from is_initialized import VaultIsInitializedAction
 from .fixtures.config import dummy_config
 
+
 class IsInitializedActionTestCase(BaseActionTestCase):
     action_cls = VaultIsInitializedAction
 

--- a/tests/test_action_is_initialized.py
+++ b/tests/test_action_is_initialized.py
@@ -1,12 +1,10 @@
-from st2tests.base import BaseActionTestCase
-
 from is_initialized import VaultIsInitializedAction
-from tests.fixtures.config import dummy_config
+from tests.vault_action_tests_base import VaultActionTestCase
 
 
-class IsInitializedActionTestCase(BaseActionTestCase):
+class IsInitializedActionTestCase(VaultActionTestCase):
     action_cls = VaultIsInitializedAction
 
     def test_method(self):
-        action = self.get_action_instance(config=dummy_config)
+        action = self.get_action_instance(config=self.dummy_pack_config)
         result = action.run()

--- a/tests/test_action_is_initialized.py
+++ b/tests/test_action_is_initialized.py
@@ -1,7 +1,7 @@
 from st2tests.base import BaseActionTestCase
 
 from is_initialized import VaultIsInitializedAction
-from .fixtures.config import dummy_config
+from tests.fixtures.config import dummy_config
 
 
 class IsInitializedActionTestCase(BaseActionTestCase):

--- a/tests/test_action_is_initialized.py
+++ b/tests/test_action_is_initialized.py
@@ -1,0 +1,10 @@
+from st2tests.base import BaseActionTestCase
+
+from is_initialized import VaultIsInitializedAction
+
+class IsInitializedActionTestCase(BaseActionTestCase):
+    action_cls = VaultIsInitializedAction
+
+    def test_method(self):
+        action = self.get_action_instance(config={'foo': 'bar'})
+        result = action.run()

--- a/tests/test_action_is_initialized.py
+++ b/tests/test_action_is_initialized.py
@@ -5,6 +5,20 @@ from tests.vault_action_tests_base import VaultActionTestCase
 class IsInitializedActionTestCase(VaultActionTestCase):
     action_cls = VaultIsInitializedAction
 
-    def test_method(self):
+    def test_already_initialized(self):
         action = self.get_action_instance(config=self.dummy_pack_config)
         result = action.run()
+        assert result is True
+
+    def test_before_and_after_initialization(self):
+        self.manager.restart_vault_cluster(perform_init=False)
+
+        action = self.get_action_instance(config=self.dummy_pack_config)
+        result = action.run()
+        assert result is False
+
+        self.manager.restart_vault_cluster(perform_init=True)
+
+        action = self.get_action_instance(config=self.dummy_pack_config)
+        result = action.run()
+        assert result is True

--- a/tests/test_action_list_policies.py
+++ b/tests/test_action_list_policies.py
@@ -1,0 +1,10 @@
+from st2tests.base import BaseActionTestCase
+
+from list_policies import VaultListPoliciesAction
+
+class ListPoliciesActionTestCase(BaseActionTestCase):
+    action_cls = VaultListPoliciesAction
+
+    def test_method(self):
+        action = self.get_action_instance(config={'foo': 'bar'})
+        result = action.run()

--- a/tests/test_action_list_policies.py
+++ b/tests/test_action_list_policies.py
@@ -3,6 +3,7 @@ from st2tests.base import BaseActionTestCase
 from list_policies import VaultPolicyListAction
 from .fixtures.config import dummy_config
 
+
 class PolicyListActionTestCase(BaseActionTestCase):
     action_cls = VaultPolicyListAction
 

--- a/tests/test_action_list_policies.py
+++ b/tests/test_action_list_policies.py
@@ -1,9 +1,9 @@
 from st2tests.base import BaseActionTestCase
 
-from list_policies import VaultListPoliciesAction
+from list_policies import VaultPolicyListAction
 
-class ListPoliciesActionTestCase(BaseActionTestCase):
-    action_cls = VaultListPoliciesAction
+class PolicyListActionTestCase(BaseActionTestCase):
+    action_cls = VaultPolicyListAction
 
     def test_method(self):
         action = self.get_action_instance(config={'foo': 'bar'})

--- a/tests/test_action_list_policies.py
+++ b/tests/test_action_list_policies.py
@@ -1,12 +1,10 @@
-from st2tests.base import BaseActionTestCase
-
 from list_policies import VaultPolicyListAction
-from tests.fixtures.config import dummy_config
+from tests.vault_action_tests_base import VaultActionTestCase
 
 
-class PolicyListActionTestCase(BaseActionTestCase):
+class PolicyListActionTestCase(VaultActionTestCase):
     action_cls = VaultPolicyListAction
 
     def test_method(self):
-        action = self.get_action_instance(config=dummy_config)
+        action = self.get_action_instance(config=self.dummy_pack_config)
         result = action.run()

--- a/tests/test_action_list_policies.py
+++ b/tests/test_action_list_policies.py
@@ -12,10 +12,10 @@ class PolicyListActionTestCase(VaultActionTestCase):
         # test
         action = self.get_action_instance(config=self.dummy_pack_config)
         result = action.run()
-        assert "stanley" in result
+        self.assertIn("stanley", result)
 
         self.client.delete_policy("stanley")
 
         action = self.get_action_instance(config=self.dummy_pack_config)
         result = action.run()
-        assert "stanley" not in result
+        self.assertNotIn("stanley", result)

--- a/tests/test_action_list_policies.py
+++ b/tests/test_action_list_policies.py
@@ -6,5 +6,16 @@ class PolicyListActionTestCase(VaultActionTestCase):
     action_cls = VaultPolicyListAction
 
     def test_method(self):
+        # setup
+        rules_text, rules_obj = self.prep_policy("stanley")
+
+        # test
         action = self.get_action_instance(config=self.dummy_pack_config)
         result = action.run()
+        assert "stanley" in result
+
+        self.client.delete_policy("stanley")
+
+        action = self.get_action_instance(config=self.dummy_pack_config)
+        result = action.run()
+        assert "stanley" not in result

--- a/tests/test_action_list_policies.py
+++ b/tests/test_action_list_policies.py
@@ -1,7 +1,7 @@
 from st2tests.base import BaseActionTestCase
 
 from list_policies import VaultPolicyListAction
-from .fixtures.config import dummy_config
+from tests.fixtures.config import dummy_config
 
 
 class PolicyListActionTestCase(BaseActionTestCase):

--- a/tests/test_action_list_policies.py
+++ b/tests/test_action_list_policies.py
@@ -1,10 +1,11 @@
 from st2tests.base import BaseActionTestCase
 
 from list_policies import VaultPolicyListAction
+from .fixtures.config import dummy_config
 
 class PolicyListActionTestCase(BaseActionTestCase):
     action_cls = VaultPolicyListAction
 
     def test_method(self):
-        action = self.get_action_instance(config={'foo': 'bar'})
+        action = self.get_action_instance(config=dummy_config)
         result = action.run()

--- a/tests/test_action_list_policies.py
+++ b/tests/test_action_list_policies.py
@@ -7,7 +7,7 @@ class PolicyListActionTestCase(VaultActionTestCase):
 
     def test_method(self):
         # setup
-        rules_text, rules_obj = self.prep_policy("stanley")
+        self.prep_policy("stanley")
 
         # test
         action = self.get_action_instance(config=self.dummy_pack_config)

--- a/tests/test_action_read.py
+++ b/tests/test_action_read.py
@@ -12,7 +12,7 @@ class ReadActionTestCase(VaultActionTestCase):
         # test
         action = self.get_action_instance(config=self.dummy_pack_config)
         result = action.run(path="secret/stanley")
-        assert result["st2"] == "awesome"
+        self.assertEqual(result["st2"], "awesome")
 
         # cleanup
         self.client.delete("secret/stanley")

--- a/tests/test_action_read.py
+++ b/tests/test_action_read.py
@@ -1,12 +1,10 @@
-from st2tests.base import BaseActionTestCase
-
 from read import VaultReadAction
-from tests.fixtures.config import dummy_config
+from tests.vault_action_tests_base import VaultActionTestCase
 
 
-class ReadActionTestCase(BaseActionTestCase):
+class ReadActionTestCase(VaultActionTestCase):
     action_cls = VaultReadAction
 
     def test_method(self):
-        action = self.get_action_instance(config=dummy_config)
+        action = self.get_action_instance(config=self.dummy_pack_config)
         result = action.run(path="")

--- a/tests/test_action_read.py
+++ b/tests/test_action_read.py
@@ -5,6 +5,14 @@ from tests.vault_action_tests_base import VaultActionTestCase
 class ReadActionTestCase(VaultActionTestCase):
     action_cls = VaultReadAction
 
-    def test_method(self):
+    def test_read_existing_key(self):
+        # setup
+        self.client.write("secret/stanley", st2="awesome")
+
+        # test
         action = self.get_action_instance(config=self.dummy_pack_config)
-        result = action.run(path="")
+        result = action.run(path="secret/stanley")
+        assert result["st2"] == "awesome"
+
+        # cleanup
+        self.client.delete("secret/stanley")

--- a/tests/test_action_read.py
+++ b/tests/test_action_read.py
@@ -1,10 +1,11 @@
 from st2tests.base import BaseActionTestCase
 
 from read import VaultReadAction
+from .fixtures.config import dummy_config
 
 class ReadActionTestCase(BaseActionTestCase):
     action_cls = VaultReadAction
 
     def test_method(self):
-        action = self.get_action_instance(config={'foo': 'bar'})
+        action = self.get_action_instance(config=dummy_config)
         result = action.run()

--- a/tests/test_action_read.py
+++ b/tests/test_action_read.py
@@ -1,0 +1,10 @@
+from st2tests.base import BaseActionTestCase
+
+from read import VaultReadAction
+
+class ReadActionTestCase(BaseActionTestCase):
+    action_cls = VaultReadAction
+
+    def test_method(self):
+        action = self.get_action_instance(config={'foo': 'bar'})
+        result = action.run()

--- a/tests/test_action_read.py
+++ b/tests/test_action_read.py
@@ -3,9 +3,10 @@ from st2tests.base import BaseActionTestCase
 from read import VaultReadAction
 from .fixtures.config import dummy_config
 
+
 class ReadActionTestCase(BaseActionTestCase):
     action_cls = VaultReadAction
 
     def test_method(self):
         action = self.get_action_instance(config=dummy_config)
-        result = action.run()
+        result = action.run(path="")

--- a/tests/test_action_read.py
+++ b/tests/test_action_read.py
@@ -1,7 +1,7 @@
 from st2tests.base import BaseActionTestCase
 
 from read import VaultReadAction
-from .fixtures.config import dummy_config
+from tests.fixtures.config import dummy_config
 
 
 class ReadActionTestCase(BaseActionTestCase):

--- a/tests/test_action_read_kv.py
+++ b/tests/test_action_read_kv.py
@@ -5,11 +5,59 @@ from tests.vault_action_tests_base import VaultActionTestCase
 class ReadKVActionTestCase(VaultActionTestCase):
     action_cls = VaultReadKVAction
 
-    def test_method(self):
+    secret_v1 = True
+    secret_v2 = True
+
+    def test_read_kv1(self):
+        mount_point = "kvv1"
+
+        # setup
+        self.client.kv.v1.create_or_update_secret(
+            path="stanley",
+            secret={"st2": "awesome"},
+            mount_point=mount_point,
+        )
+
+
+        # test
         action = self.get_action_instance(config=self.dummy_pack_config)
         result = action.run(
-            path="",
+            path="stanley",
             kv_version=1,
-            mount_point="",
+            mount_point=mount_point,
             version="1",
+        )
+        assert result["st2"] == "awesome"
+
+        # cleanup
+        self.client.kv.v1.delete_secret(
+            path="stanley",
+            mount_point=mount_point,
+        )
+
+    def test_read_kv2(self):
+        mount_point = "kvv2"
+
+        # setup
+        self.client.kv.v2.create_or_update_secret(
+            path="stanley",
+            secret={"st2": "awesome"},
+            mount_point=mount_point,
+        )
+
+        # test
+        action = self.get_action_instance(config=self.dummy_pack_config)
+        result = action.run(
+            path="stanley",
+            kv_version=2,
+            mount_point=mount_point,
+            version="1",
+        )
+        # v2 puts the secret one level deeper than v1
+        assert result["data"]["st2"] == "awesome"
+
+        # cleanup
+        self.client.kv.v2.delete_metadata_and_all_versions(
+            path="stanley",
+            mount_point=mount_point,
         )

--- a/tests/test_action_read_kv.py
+++ b/tests/test_action_read_kv.py
@@ -1,10 +1,11 @@
 from st2tests.base import BaseActionTestCase
 
 from read_kv import VaultReadKVAction
+from .fixtures.config import dummy_config
 
 class ReadKVActionTestCase(BaseActionTestCase):
     action_cls = VaultReadKVAction
 
     def test_method(self):
-        action = self.get_action_instance(config={'foo': 'bar'})
+        action = self.get_action_instance(config=dummy_config)
         result = action.run()

--- a/tests/test_action_read_kv.py
+++ b/tests/test_action_read_kv.py
@@ -1,14 +1,12 @@
-from st2tests.base import BaseActionTestCase
-
 from read_kv import VaultReadKVAction
-from tests.fixtures.config import dummy_config
+from tests.vault_action_tests_base import VaultActionTestCase
 
 
-class ReadKVActionTestCase(BaseActionTestCase):
+class ReadKVActionTestCase(VaultActionTestCase):
     action_cls = VaultReadKVAction
 
     def test_method(self):
-        action = self.get_action_instance(config=dummy_config)
+        action = self.get_action_instance(config=self.dummy_pack_config)
         result = action.run(
             path="",
             kv_version=1,

--- a/tests/test_action_read_kv.py
+++ b/tests/test_action_read_kv.py
@@ -26,7 +26,7 @@ class ReadKVActionTestCase(VaultActionTestCase):
             mount_point=mount_point,
             version="1",
         )
-        assert result["st2"] == "awesome"
+        self.assertEqual(result["st2"], "awesome")
 
         # cleanup
         self.client.kv.v1.delete_secret(
@@ -53,7 +53,7 @@ class ReadKVActionTestCase(VaultActionTestCase):
             version="1",
         )
         # v2 puts the secret one level deeper than v1
-        assert result["data"]["st2"] == "awesome"
+        self.assertEqual(result["data"]["st2"], "awesome")
 
         # cleanup
         self.client.kv.v2.delete_metadata_and_all_versions(

--- a/tests/test_action_read_kv.py
+++ b/tests/test_action_read_kv.py
@@ -3,9 +3,15 @@ from st2tests.base import BaseActionTestCase
 from read_kv import VaultReadKVAction
 from .fixtures.config import dummy_config
 
+
 class ReadKVActionTestCase(BaseActionTestCase):
     action_cls = VaultReadKVAction
 
     def test_method(self):
         action = self.get_action_instance(config=dummy_config)
-        result = action.run()
+        result = action.run(
+            path="",
+            kv_version=1,
+            mount_point="",
+            version="1",
+        )

--- a/tests/test_action_read_kv.py
+++ b/tests/test_action_read_kv.py
@@ -1,7 +1,7 @@
 from st2tests.base import BaseActionTestCase
 
 from read_kv import VaultReadKVAction
-from .fixtures.config import dummy_config
+from tests.fixtures.config import dummy_config
 
 
 class ReadKVActionTestCase(BaseActionTestCase):

--- a/tests/test_action_read_kv.py
+++ b/tests/test_action_read_kv.py
@@ -1,0 +1,10 @@
+from st2tests.base import BaseActionTestCase
+
+from read_kv import VaultReadKVAction
+
+class ReadKVActionTestCase(BaseActionTestCase):
+    action_cls = VaultReadKVAction
+
+    def test_method(self):
+        action = self.get_action_instance(config={'foo': 'bar'})
+        result = action.run()

--- a/tests/test_action_read_kv.py
+++ b/tests/test_action_read_kv.py
@@ -18,7 +18,6 @@ class ReadKVActionTestCase(VaultActionTestCase):
             mount_point=mount_point,
         )
 
-
         # test
         action = self.get_action_instance(config=self.dummy_pack_config)
         result = action.run(

--- a/tests/test_action_set_policy.py
+++ b/tests/test_action_set_policy.py
@@ -11,14 +11,7 @@ class PolicySetActionTestCase(VaultActionTestCase):
         path "sys" { policy = "deny" }
         path "secret" { policy = "write" }
         """
-        rules_obj = {
-            "path": {
-                "sys": {
-                    "policy": "deny"},
-                "secret": {
-                    "policy": "write"}
-            }
-        }
+        # rules_obj = {"path": {"sys": {"policy": "deny"}, "secret": {"policy": "write"}}}
 
         action = self.get_action_instance(config=self.dummy_pack_config)
         action_result = action.run(

--- a/tests/test_action_set_policy.py
+++ b/tests/test_action_set_policy.py
@@ -1,14 +1,12 @@
-from st2tests.base import BaseActionTestCase
-
 from set_policy import VaultPolicySetAction
-from tests.fixtures.config import dummy_config
+from tests.vault_action_tests_base import VaultActionTestCase
 
 
-class PolicySetActionTestCase(BaseActionTestCase):
+class PolicySetActionTestCase(VaultActionTestCase):
     action_cls = VaultPolicySetAction
 
     def test_method(self):
-        action = self.get_action_instance(config=dummy_config)
+        action = self.get_action_instance(config=self.dummy_pack_config)
         result = action.run(
             name="",
             rules="",

--- a/tests/test_action_set_policy.py
+++ b/tests/test_action_set_policy.py
@@ -1,0 +1,10 @@
+from st2tests.base import BaseActionTestCase
+
+from set_policy import VaultSetPolicyAction
+
+class SetPolicyActionTestCase(BaseActionTestCase):
+    action_cls = VaultSetPolicyAction
+
+    def test_method(self):
+        action = self.get_action_instance(config={'foo': 'bar'})
+        result = action.run()

--- a/tests/test_action_set_policy.py
+++ b/tests/test_action_set_policy.py
@@ -3,9 +3,13 @@ from st2tests.base import BaseActionTestCase
 from set_policy import VaultPolicySetAction
 from .fixtures.config import dummy_config
 
+
 class PolicySetActionTestCase(BaseActionTestCase):
     action_cls = VaultPolicySetAction
 
     def test_method(self):
         action = self.get_action_instance(config=dummy_config)
-        result = action.run()
+        result = action.run(
+            name="",
+            rules="",
+        )

--- a/tests/test_action_set_policy.py
+++ b/tests/test_action_set_policy.py
@@ -18,10 +18,10 @@ class PolicySetActionTestCase(VaultActionTestCase):
             name="stanley",
             rules=rules_text,
         )
-        assert action_result is None
+        self.assertIsNone(action_result)
 
         result = self.client.get_policy("stanley")
-        assert result == rules_text
+        self.assertEqual(result, rules_text)
 
         # cleanup
         self.client.delete_policy("stanley")

--- a/tests/test_action_set_policy.py
+++ b/tests/test_action_set_policy.py
@@ -6,8 +6,29 @@ class PolicySetActionTestCase(VaultActionTestCase):
     action_cls = VaultPolicySetAction
 
     def test_method(self):
+        # same as self.prep_policy
+        rules_text = """
+        path "sys" { policy = "deny" }
+        path "secret" { policy = "write" }
+        """
+        rules_obj = {
+            "path": {
+                "sys": {
+                    "policy": "deny"},
+                "secret": {
+                    "policy": "write"}
+            }
+        }
+
         action = self.get_action_instance(config=self.dummy_pack_config)
-        result = action.run(
-            name="",
-            rules="",
+        action_result = action.run(
+            name="stanley",
+            rules=rules_text,
         )
+        assert action_result is None
+
+        result = self.client.get_policy("stanley")
+        assert result == rules_text
+
+        # cleanup
+        self.client.delete_policy("stanley")

--- a/tests/test_action_set_policy.py
+++ b/tests/test_action_set_policy.py
@@ -1,9 +1,9 @@
 from st2tests.base import BaseActionTestCase
 
-from set_policy import VaultSetPolicyAction
+from set_policy import VaultPolicySetAction
 
-class SetPolicyActionTestCase(BaseActionTestCase):
-    action_cls = VaultSetPolicyAction
+class PolicySetActionTestCase(BaseActionTestCase):
+    action_cls = VaultPolicySetAction
 
     def test_method(self):
         action = self.get_action_instance(config={'foo': 'bar'})

--- a/tests/test_action_set_policy.py
+++ b/tests/test_action_set_policy.py
@@ -1,10 +1,11 @@
 from st2tests.base import BaseActionTestCase
 
 from set_policy import VaultPolicySetAction
+from .fixtures.config import dummy_config
 
 class PolicySetActionTestCase(BaseActionTestCase):
     action_cls = VaultPolicySetAction
 
     def test_method(self):
-        action = self.get_action_instance(config={'foo': 'bar'})
+        action = self.get_action_instance(config=dummy_config)
         result = action.run()

--- a/tests/test_action_set_policy.py
+++ b/tests/test_action_set_policy.py
@@ -1,7 +1,7 @@
 from st2tests.base import BaseActionTestCase
 
 from set_policy import VaultPolicySetAction
-from .fixtures.config import dummy_config
+from tests.fixtures.config import dummy_config
 
 
 class PolicySetActionTestCase(BaseActionTestCase):

--- a/tests/test_action_write.py
+++ b/tests/test_action_write.py
@@ -3,9 +3,13 @@ from st2tests.base import BaseActionTestCase
 from write import VaultWriteAction
 from .fixtures.config import dummy_config
 
+
 class WriteActionTestCase(BaseActionTestCase):
     action_cls = VaultWriteAction
 
     def test_method(self):
         action = self.get_action_instance(config=dummy_config)
-        result = action.run()
+        result = action.run(
+            path="",
+            values="",
+        )

--- a/tests/test_action_write.py
+++ b/tests/test_action_write.py
@@ -1,10 +1,8 @@
-from st2tests.base import BaseActionTestCase
-
 from write import VaultWriteAction
-from tests.fixtures.config import dummy_config
+from tests.vault_action_tests_base import VaultActionTestCase
 
 
-class WriteActionTestCase(BaseActionTestCase):
+class WriteActionTestCase(VaultActionTestCase):
     action_cls = VaultWriteAction
 
     def test_method(self):

--- a/tests/test_action_write.py
+++ b/tests/test_action_write.py
@@ -13,10 +13,10 @@ class WriteActionTestCase(VaultActionTestCase):
             values='{"st2": "awesome"}',
         )
         # action_result is a requests.response object
-        assert action_result is not None
+        self.assertIsNotNone(action_result)
 
         result = self.client.read("secret/stanley")
-        assert result["data"]["st2"] == "awesome"
+        self.assertEqual(result["data"]["st2"], "awesome")
 
         # cleanup
         self.client.delete("secret/stanley")

--- a/tests/test_action_write.py
+++ b/tests/test_action_write.py
@@ -5,9 +5,17 @@ from tests.vault_action_tests_base import VaultActionTestCase
 class WriteActionTestCase(VaultActionTestCase):
     action_cls = VaultWriteAction
 
-    def test_method(self):
-        action = self.get_action_instance(config=dummy_config)
-        result = action.run(
-            path="",
-            values="",
+    def test_write_key(self):
+        # test
+        action = self.get_action_instance(config=self.dummy_pack_config)
+        action_result = action.run(
+            path="secret/stanley",
+            values='{"st2": "awesome"}',
         )
+        # action_result is a requests.response object
+
+        result = self.client.read("secret/stanley")
+        assert result["data"]["st2"] == "awesome"
+
+        # cleanup
+        self.client.delete("secret/stanley")

--- a/tests/test_action_write.py
+++ b/tests/test_action_write.py
@@ -13,6 +13,7 @@ class WriteActionTestCase(VaultActionTestCase):
             values='{"st2": "awesome"}',
         )
         # action_result is a requests.response object
+        assert action_result is not None
 
         result = self.client.read("secret/stanley")
         assert result["data"]["st2"] == "awesome"

--- a/tests/test_action_write.py
+++ b/tests/test_action_write.py
@@ -1,7 +1,7 @@
 from st2tests.base import BaseActionTestCase
 
 from write import VaultWriteAction
-from .fixtures.config import dummy_config
+from tests.fixtures.config import dummy_config
 
 
 class WriteActionTestCase(BaseActionTestCase):

--- a/tests/test_action_write.py
+++ b/tests/test_action_write.py
@@ -1,10 +1,11 @@
 from st2tests.base import BaseActionTestCase
 
 from write import VaultWriteAction
+from .fixtures.config import dummy_config
 
 class WriteActionTestCase(BaseActionTestCase):
     action_cls = VaultWriteAction
 
     def test_method(self):
-        action = self.get_action_instance(config={'foo': 'bar'})
+        action = self.get_action_instance(config=dummy_config)
         result = action.run()

--- a/tests/test_action_write.py
+++ b/tests/test_action_write.py
@@ -1,0 +1,10 @@
+from st2tests.base import BaseActionTestCase
+
+from write import VaultWriteAction
+
+class WriteActionTestCase(BaseActionTestCase):
+    action_cls = VaultWriteAction
+
+    def test_method(self):
+        action = self.get_action_instance(config={'foo': 'bar'})
+        result = action.run()

--- a/tests/vault_action_tests_base.py
+++ b/tests/vault_action_tests_base.py
@@ -62,21 +62,16 @@ class VaultActionTestCase(HvacIntegrationTestCase, BaseActionTestCase):
 
         dummy_pack_config = {
             "url": url,
-
             # pack config | relation | hvac.Client()
             # ------------|----------|--------------
             #    cert     |    !=    |     cert
             # cert+verify |    ==    |    verify
             "cert": server_cert_path,
             "verify": True,
-
             "auth_method": "token",
-
             "token": token,
-
             "role_id": None,
             "secret_id": None,
         }
 
         return dummy_pack_config
-

--- a/tests/vault_action_tests_base.py
+++ b/tests/vault_action_tests_base.py
@@ -10,15 +10,17 @@ class VaultActionTestCase(HvacIntegrationTestCase, BaseActionTestCase):
     secret_v2 = False
     default_token_lease = "1h"
 
-    # in setUp() and tearDown(), explicitly handle super()-like calls.
-    #  - HvacIntegrationTestCase does not call super().
-    #  - BaseActionTestCase does call super().
+    # NB: self.client has a root_token. Use for test setup, but not for action tests.
 
     def setUp(self):
-        HvacIntegrationTestCase.setUp(self)
-        # self.client = create_client(token=self.manager.root_token)
-        # also mocks hvac.utils.warnings which we might not want.
-        BaseActionTestCase.setUp(self)
+        # NOTE: HvacIntegrationTestCase.setUp() mocks hvac.utils.warnings
+        # which means that deprecations warnings will be swallowed in CI.
+        # We might need to work around that at some point.
+
+        super(VaultActionTestCase, self).setUp()
+        # HvacIntegrationTestCase does not call super(), so we take care of that.
+        super(HvacIntegrationTestCase, self).setUp()
+
         self.dummy_pack_config = self.build_dummy_pack_config()
 
         mounted_secrets_engines = self.client.sys.list_mounted_secrets_engines()["data"]
@@ -45,8 +47,10 @@ class VaultActionTestCase(HvacIntegrationTestCase, BaseActionTestCase):
             )
 
     def tearDown(self):
-        BaseActionTestCase.tearDown(self)
-        HvacIntegrationTestCase.tearDown(self)
+        # HvacIntegrationTestCase does not call super(), so we take care of that.
+        super(HvacIntegrationTestCase, self).setUp()
+        super(VaultActionTestCase, self).setUp()
+
         self.dummy_pack_config = None
         if self.secret_v1:
             self.client.disable_secret_backend(mount_point="kvv1")

--- a/tests/vault_action_tests_base.py
+++ b/tests/vault_action_tests_base.py
@@ -1,0 +1,61 @@
+from st2tests.base import BaseActionTestCase
+
+from tests.utils import get_config_file_path
+from tests.utils.hvac_integration_test_case import HvacIntegrationTestCase
+
+
+class VaultActionTestCase(HvacIntegrationTestCase, BaseActionTestCase):
+    dummy_pack_config = None
+
+    # in setUp() and tearDown(), explicitly handle super()-like calls.
+    #  - HvacIntegrationTestCase does not call super().
+    #  - BaseActionTestCase does call super().
+
+    def setUp(self):
+        HvacIntegrationTestCase.setUp(self)
+        # self.client = create_client(token=self.manager.root_token)
+        # also mocks hvac.utils.warnings which we might not want.
+        BaseActionTestCase.setUp(self)
+        self.dummy_pack_config = self.build_dummy_pack_config()
+
+        # based on hvac/tests/integration_tests/v1/test_integration.py
+        if 'secret/' not in self.client.sys.list_mounted_secrets_engines()['data']:
+            self.client.enable_secret_backend(
+                backend_type='kv',
+                mount_point='secret',
+                options=dict(version=1),
+            )
+
+    def tearDown(self):
+        BaseActionTestCase.tearDown(self)
+        HvacIntegrationTestCase.tearDown(self)
+        self.dummy_config = None
+
+
+    def build_dummy_pack_config(self, url='https://localhost:8200'):
+        # based on create_client() in hvac/tests/utils/__init__.py
+        server_cert_path = get_config_file_path('server-cert.pem')
+
+        token_result = self.client.create_token(lease="1h")
+        token = token_result["auth"]["client_token"]
+
+        dummy_config = {
+            "url": url,
+
+            # pack config | relation | hvac.Client()
+            # ------------|----------|--------------
+            #    cert     |    !=    |     cert
+            # cert+verify |    ==    |    verify
+            "cert": server_cert_path,
+            "verify": True,
+
+            "auth_method": "token",
+
+            "token": token,
+
+            "role_id": None,
+            "secret_id": None,
+        }
+
+        return dummy_config
+

--- a/tests/vault_action_tests_base.py
+++ b/tests/vault_action_tests_base.py
@@ -47,9 +47,9 @@ class VaultActionTestCase(HvacIntegrationTestCase, BaseActionTestCase):
             )
 
     def tearDown(self):
+        super(VaultActionTestCase, self).setUp()
         # HvacIntegrationTestCase does not call super(), so we take care of that.
         super(HvacIntegrationTestCase, self).setUp()
-        super(VaultActionTestCase, self).setUp()
 
         self.dummy_pack_config = None
         if self.secret_v1:

--- a/tests/vault_action_tests_base.py
+++ b/tests/vault_action_tests_base.py
@@ -47,9 +47,9 @@ class VaultActionTestCase(HvacIntegrationTestCase, BaseActionTestCase):
             )
 
     def tearDown(self):
-        super(VaultActionTestCase, self).setUp()
+        super(VaultActionTestCase, self).tearDown()
         # HvacIntegrationTestCase does not call super(), so we take care of that.
-        super(HvacIntegrationTestCase, self).setUp()
+        super(HvacIntegrationTestCase, self).tearDown()
 
         self.dummy_pack_config = None
         if self.secret_v1:

--- a/tests/vault_action_tests_base.py
+++ b/tests/vault_action_tests_base.py
@@ -8,6 +8,7 @@ class VaultActionTestCase(HvacIntegrationTestCase, BaseActionTestCase):
     dummy_pack_config = None
     secret_v1 = False
     secret_v2 = False
+    default_token_lease = "1h"
 
     # in setUp() and tearDown(), explicitly handle super()-like calls.
     #  - HvacIntegrationTestCase does not call super().
@@ -56,7 +57,7 @@ class VaultActionTestCase(HvacIntegrationTestCase, BaseActionTestCase):
         # based on create_client() in hvac/tests/utils/__init__.py
         server_cert_path = get_config_file_path("server-cert.pem")
 
-        token_result = self.client.create_token(lease="1h")
+        token_result = self.client.create_token(lease=self.default_token_lease)
         token = token_result["auth"]["client_token"]
 
         dummy_pack_config = {


### PR DESCRIPTION
Add tests for all actions.

To do this, we reuse the hvac testing infra to setup consul/vault for our tests.

Also, we drop the broken python2.7 tests and update the CI config to use the latest from StackStorm-Exchange/ci.

~This depends on~ This demonstrates how StackStorm-Exchange/ci#101 will behave by running the `setup_testing_env.sh` script immediately following `dependencies`.