### PR TITLE
Move hvac checkout to .hvac

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,6 @@ jobs:
       # Don't install various StackStorm dependencies which are already
       # installed by CI again in the various check scripts
       ST2_INSTALL_DEPS: "0"
-      FORCE_CHECK_ALL_FILES: 'true'
 
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,7 @@ jobs:
       # Don't install various StackStorm dependencies which are already
       # installed by CI again in the various check scripts
       ST2_INSTALL_DEPS: "0"
+      FORCE_CHECK_ALL_FILES: 'true'
 
     steps:
       - checkout

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 # hvac tests (see tests/setup_testing_env.sh)
 # - hvac is where CI checks out the git repo
-hvac
+.hvac
 # - tests/utils should be a symlink to tests/utils in an hvac git checkout
 tests/utils
 tests/config_files

--- a/tests/setup_testing_env.sh
+++ b/tests/setup_testing_env.sh
@@ -15,7 +15,7 @@ set -eux
 # This script is called by `deployment` housed in StackStorm-exchange/ci.
 # `deployment` will only run this script if it is executable.
 ROOT_DIR="${ROOT_DIR:-$(pwd)}"
-HVAC_DIR="${ROOT_DIR}/hvac"
+HVAC_DIR="${ROOT_DIR}/.hvac"
 
 # main = the release branch; devel = the active development branch
 git clone -b main git://github.com/hvac/hvac.git "${HVAC_DIR}"


### PR DESCRIPTION
When merging with master, we use the `/home/circleci/repo/*` glob to run flake8 against all the files. But hvac has different standards, so we want to exclude it. `*` does not match dot files, so use that instead.