### PR TITLE
Add Kubernetes Auth Method

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 1.1.0
+
+- Added `kuberentes` auth method.
+
 ## 1.0.0
 
 * Drop Python 2.7 support

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ## 1.1.0
 
 - Added `kuberentes` auth method.
+- Added `auth_mount_point` config option for specifying custom authentication mount points.
 
 ## 1.0.0
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ It should contain:
 * `cert` - Path to client-side certificate
 * `verify` - Whether to verify the SSL certificate or not
 * `auth_method` - Which authentication method to use.
-  Only `token` (the default) and `approle` are implemented so far.
+  Only `token` (the default), `approle` and `kubernetes` are implemented so far.
 
 Also include the relevant auth_method-specific config:
 
@@ -21,6 +21,7 @@ Also include the relevant auth_method-specific config:
   also tries using the `VAULT_TOKEN` env var or the `~/.vault-token` file.
 * `role_id` - Authentication role_id for `auth_method=approle`.
 * `secret_id` - Authentication secret_id for `auth_method=approle`.
+* `role` - Authentication role for `auth_method=kubernetes`
 
 You can also use dynamic values from the datastore. See the
 [docs](https://docs.stackstorm.com/reference/pack_configs.html) for more info.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ It should contain:
 * `cert` - Path to client-side certificate
 * `verify` - Whether to verify the SSL certificate or not
 * `auth_method` - Which authentication method to use.
-  Only `token` (the default), `approle` and `kubernetes` are implemented so far.
+  Available implementations are: `token` (default), `approle` and `kubernetes`.
 
 Also include the relevant auth_method-specific config:
 

--- a/actions/lib/action.py
+++ b/actions/lib/action.py
@@ -33,6 +33,12 @@ class VaultBaseAction(Action):
                 role_id=self.config["role_id"],
                 secret_id=self.config["secret_id"],
             )
+        elif auth_method == "kubernetes":
+            with open("/var/run/secrets/kubernetes.io/serviceaccount/token") as sa_token:
+                client.auth.kubernetes.login(
+                    self.config["role"],
+                    sa_token.read(),
+                )
         else:
             raise NotImplementedError(
                 "The {} auth method has a typo or has not been implemented (yet).".format(

--- a/config.schema.yaml
+++ b/config.schema.yaml
@@ -22,6 +22,7 @@
     enum:
       - approle
       - token
+      - kubernetes
       # Not implemented:
       # - app-id
       # - ali-cloud
@@ -32,7 +33,6 @@
       # - gcp
       # - github
       # - jwt
-      # - kubernetes
       # - ldap
       # - mfa
       # - oidc
@@ -55,4 +55,8 @@
     description: "Authentication approle secret-id (method=approle)"
     type: "string"
     secret: true
+    required: false
+  role:
+    description: "Authentication role (method=kubernetes)"
+    secret: false
     required: false

--- a/config.schema.yaml
+++ b/config.schema.yaml
@@ -40,7 +40,11 @@
       # - radius
       # - userpass
     required: false
-  
+
+  auth_mount_point:
+    description: "Custom authentication mount point, if required"
+    type: "string"
+    required: false
   token:
     description: "Authentication token (method=token)"
     type: "string"

--- a/pack.yaml
+++ b/pack.yaml
@@ -2,7 +2,7 @@
 ref: vault
 name: vault
 description: HashiCorp Vault
-version: 1.0.0
+version: 1.1.0
 python_versions:
   - "3"
 author: steve.neuharth


### PR DESCRIPTION
Stackstorm-ha, by default, runs in Kubernetes (which is how I've got ST2 deployed). This PR should add support for Vault's Kubernetes auth method to the pack.

Draft, while I test it locally on my own deployment, but to give you the heads up this is coming.