### PR TITLE
Work around TLS errors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,6 +33,11 @@ jobs:
             echo "Setting up custom pack testing environment with tests/setup_testing_env.sh"
             source ~/virtualenv/bin/activate
             tests/setup_testing_env.sh
+            set -x
+            which nosetests
+            # eventlet monkey_patch as early as possible
+            sed -i -e '/^import re$/i from st2common.util.monkey_patch import monkey_patch\nmonkey_patch()' $(which nosetests)
+            head -n5 $(which nosetests)
       - run:
           name: Run tests (Python 3.6)
           # NOTE: We don't want to use default "-e" option because this means

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,10 +33,6 @@ jobs:
             echo "Setting up custom pack testing environment with tests/setup_testing_env.sh"
             source ~/virtualenv/bin/activate
             tests/setup_testing_env.sh
-            set -x
-            which nosetests
-            # eventlet monkey_patch as early as possible (has to be in activate as nosetests gets reinstalled during test phase)
-            echo "grep -q monkey_patch $(which nosetests) || sed -i -e '/^import re$/i from st2common.util.monkey_patch import monkey_patch\nmonkey_patch()' $(which nosetests)" >> ~/virtualenv/bin/activate
       - run:
           name: Run tests (Python 3.6)
           # NOTE: We don't want to use default "-e" option because this means
@@ -44,7 +40,10 @@ jobs:
           # can't intercept the error and cause non-fatal exit in case pack
           # doesn't declare support for Python 3
           shell: /bin/bash
-          command: ~/ci/.circle/test ; ~/ci/.circle/exit_on_py3_checks $?
+          # eventlet monkey_patch as early as possible (has to be in activate as nosetests gets reinstalled during test phase)
+          command: |
+            echo "grep -q monkey_patch ~/virtualenv/bin/nosetests || sed -i -e '/^import re$/i from st2common.util.monkey_patch import monkey_patch\nmonkey_patch()' ~/virtualenv/bin/nosetests" >> ~/virtualenv/bin/activate
+            ~/ci/.circle/test ; ~/ci/.circle/exit_on_py3_checks $?
       - save_cache:
           key: v1-dependency-cache-py36-{{ checksum "requirements.txt" }}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,8 @@ jobs:
           shell: /bin/bash
           # eventlet monkey_patch as early as possible (has to be in activate as nosetests gets reinstalled during test phase)
           command: |
-            echo "grep -q monkey_patch ~/virtualenv/bin/nosetests || sed -i -e '/^import re$/i from st2common.util.monkey_patch import monkey_patch\nmonkey_patch()' ~/virtualenv/bin/nosetests" >> ~/virtualenv/bin/activate
+            echo "grep -q monkey_patch ~/virtualenv/bin/nosetests || sed -i -e '/^import re$/i from st2common.util.monkey_patch import monkey_patch\nmonkey_patch()\n' ~/virtualenv/bin/nosetests" >> ~/virtualenv/bin/activate
+            echo "grep -q pyopenssl\\.inject ~/virtualenv/bin/nosetests || sed -i -e '/^import re$/i from urllib3.contrib import pyopenssl\npyopenssl.inject_into_urllib3()\n' ~/virtualenv/bin/nosetests" >> ~/virtualenv/bin/activate
             ~/ci/.circle/test ; ~/ci/.circle/exit_on_py3_checks $?
       - save_cache:
           key: v1-dependency-cache-py36-{{ checksum "requirements.txt" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,9 +35,8 @@ jobs:
             tests/setup_testing_env.sh
             set -x
             which nosetests
-            # eventlet monkey_patch as early as possible
-            sed -i -e '/^import re$/i from st2common.util.monkey_patch import monkey_patch\nmonkey_patch()' $(which nosetests)
-            head -n5 $(which nosetests)
+            # eventlet monkey_patch as early as possible (has to be in activate as nosetests gets reinstalled during test phase)
+            echo "grep -q monkey_patch $(which nosetests) || sed -i -e '/^import re$/i from st2common.util.monkey_patch import monkey_patch\nmonkey_patch()' $(which nosetests)" >> ~/virtualenv/bin/activate
       - run:
           name: Run tests (Python 3.6)
           # NOTE: We don't want to use default "-e" option because this means

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,9 @@
+# with requests <=2.23.0, requests forced a re-import of ssl libs.
+# Once it stopped doing that, the ssl module was imported somewhere
+# before eventlet monkey patching occurred, resulting in some
+# infinite recursion errors. Putting this in the base test file
+# or in the individual test files was not soon enough. Putting this
+# here does, however, seem to be early enough to resolve the errors.
+from st2common.util.monkey_patch import monkey_patch
+
+monkey_patch()

--- a/tests/vault_action_tests_base.py
+++ b/tests/vault_action_tests_base.py
@@ -1,3 +1,9 @@
+# workaround messed up ssl module on CircleCI (it hits an infinite recursion loop).
+# this restores behavior of requests <=2.23.0 (see https://github.com/psf/requests/pull/5443)
+from urllib3.contrib import pyopenssl
+
+pyopenssl.inject_into_urllib3()
+
 from st2tests.base import BaseActionTestCase
 
 from tests.utils import get_config_file_path

--- a/tests/vault_action_tests_base.py
+++ b/tests/vault_action_tests_base.py
@@ -1,9 +1,3 @@
-# workaround messed up ssl module on CircleCI (it hits an infinite recursion loop).
-# this restores behavior of requests <=2.23.0 (see https://github.com/psf/requests/pull/5443)
-from urllib3.contrib import pyopenssl
-
-pyopenssl.inject_into_urllib3()
-
 from st2tests.base import BaseActionTestCase
 
 from tests.utils import get_config_file_path


### PR DESCRIPTION
For some reason the ssl module is hitting an infinite recursion error. I thought this might be CircleCI-specific, but I was able to reproduce it locally with v3.6.13. The 3.7.0 version is supposed to be even more robust, so it could also be something about v3.6.13. ~I have not reproduced the error elsewhere, however.~ _I was able to reproduce the error locally._

The error began appearing after we updated requests from v2.23.0 to v2.25.1 in StackStorm/st2#5215
In requests v2.24.0, it defaulted to using the python ssl module instead of PyOpenSSL due to various SELinux issues. Before that it used PyOpenSSL whenever it was installed. Since it worked with pyopenssl, we just revert to using it for the tests in this repo.
See: psf/requests#5443