### PR TITLE
add maintainers list

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,17 @@
+# This is a comment.
+# Each line is a file pattern followed by one or more owners.
+
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence, users and
+# teams which are put in owners will be requested for review
+# when someone opens a pull request.
+
+# This is base configuration. These owners could review the
+# changes in all files in this repository.
+* @cognifloyd
+
+# CI configuration files should be reviewed by specific owners
+# who are more responsible for ensuring the quality of this pack
+# or orchestrate StackStorm-Exchanges.
+.circleci/** @StackStorm-Exchange/tsc
+.github/CODEOWNERS @StackStorm-Exchange/tsc

--- a/README.md
+++ b/README.md
@@ -38,3 +38,7 @@ You can also use dynamic values from the datastore. See the
 * `read` - Read value from Vault server
 * `write` - Write key/value to Vault server
 * `read_kv` - Read key-value secrets from Vault server
+
+## Maintainers
+Active pack maintainers with review & write repository access and expertise with vault:
+* Jacob Floyd ([@cognifloyd](https://github.com/cognifloyd)) <cognifloyd@gmail.com> Copart


### PR DESCRIPTION
Add CODEOWNERS as described in https://github.com/StackStorm-Exchange/exchange-incubator/issues/152

Who else should be included in the maintainers list?

I did not include TSC in `*` because I think that is far too aggressive. Only a few of the TSC members
actively maintain packs across the exchange. We shouldn't spam everyone else.

A new group might be nice to specify "people who maintain all packs on the exchange".
